### PR TITLE
NFC: Settings has stopped due to NFC service

### DIFF
--- a/src/com/android/nfc/NfcService.java
+++ b/src/com/android/nfc/NfcService.java
@@ -1731,7 +1731,7 @@ public class NfcService implements DeviceHostListener {
 
         @Override
         public INfcCardEmulation getNfcCardEmulationInterface() {
-            if (mIsHceCapable) {
+            if (mIsHceCapable && mCardEmulationManager != null) {
                 return mCardEmulationManager.getNfcCardEmulationInterface();
             } else {
                 return null;


### PR DESCRIPTION
There is synchronization problem which is causing exception,
flag is true but card emulation manager is not initialized yet.

Null check added in dead service recovery process
to prevent exception.

Change-Id: I3dbc1dcb5578ed0b5abf316a15c0d5318be1ddd1
CRs-Fixed: 1032243